### PR TITLE
Update methods.js

### DIFF
--- a/js/methods.js
+++ b/js/methods.js
@@ -19,7 +19,7 @@ function RefreshDashboardData() {
                             var vdata = item[vtype];
                             var vunit = "";
 
-                            if (vattr != 'scene' || vattr != 'group') {
+                            if (vattr != 'scene' && vattr != 'group') {
                                 if (typeof vdata == 'undefined') {
                                     vdata = "??";
                                 } else {


### PR DESCRIPTION
First of all, thanks for the nice interface. While creating my own dashboard, I noticed this condition in methods.js: if (vattr != 'scene' || vattr != 'group'), which is always true. you can easily see this when I write it as follows: ( a != b || a != c) <==> ! (a==b && a==c). Given that b and c ('scene' and 'group' in the specific case) are unequal this negated and-statement will allways be true.
I'm quite sure you intended to write:  if (vattr != 'scene' && vattr != 'group')
